### PR TITLE
Bug fix/handle query abortion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@deck.gl/core": "^9.3.0",
         "@deck.gl/layers": "^9.3.0",
         "@deck.gl/mapbox": "^9.3.0",
-        "@duckdb/duckdb-wasm": "^1.33.1-dev45.0",
+        "@duckdb/duckdb-wasm": "^1.32.0",
         "@geoarrow/deck.gl-layers": "^0.3.2",
         "@mdi/font": "^7.4.47",
         "@theace0296/vue-snotify": "^4.0.4",
@@ -254,13 +254,12 @@
       }
     },
     "node_modules/@duckdb/duckdb-wasm": {
-      "version": "1.33.1-dev45.0",
-      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.33.1-dev45.0.tgz",
-      "integrity": "sha512-ETlrjhiGQzNdaOhpro/Y9u/RCcK+iyuczLy7uOn0kG5Mqlj8C+gTuhBXjs4JpK9ocdUgr3oT8zYYIbUnFD9AYA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.32.0.tgz",
+      "integrity": "sha512-IewXTNYEjsZCPE9weUWgtjGxUlMRo7qhX0GF6tq/KjK8bnY+RAl4cyUdYUfcdzbyb4b9ZxPC+FOsCcxgaKFWMg==",
       "license": "MIT",
       "dependencies": {
-        "apache-arrow": "^17.0.0",
-        "qs": "^6.14.1"
+        "apache-arrow": "^17.0.0"
       }
     },
     "node_modules/@duckdb/duckdb-wasm/node_modules/@types/node": {
@@ -2522,35 +2521,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2799,20 +2769,6 @@
       "license": "Apache-2.0",
       "peer": true
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/earcut": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
@@ -2829,36 +2785,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -3300,52 +3226,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/gl-matrix": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
@@ -3378,18 +3258,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/h3-js": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-4.4.0.tgz",
@@ -3409,30 +3277,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/ieee754": {
@@ -4036,15 +3880,6 @@
         "pbf": "bin/pbf"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/md5": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
@@ -4155,18 +3990,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/observable-fns": {
@@ -4424,21 +4247,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/quickselect": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
@@ -4600,78 +4408,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/snappyjs": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@deck.gl/core": "^9.3.0",
     "@deck.gl/layers": "^9.3.0",
     "@deck.gl/mapbox": "^9.3.0",
-    "@duckdb/duckdb-wasm": "^1.33.1-dev45.0",
+    "@duckdb/duckdb-wasm": "^1.32.0",
     "@geoarrow/deck.gl-layers": "^0.3.2",
     "@mdi/font": "^7.4.47",
     "@theace0296/vue-snotify": "^4.0.4",

--- a/src/App.vue
+++ b/src/App.vue
@@ -25,7 +25,7 @@
           class="content-panels d-flex flex-grow-1"
           style="min-height: 0; position: relative"
         >
-          <LoadingOverlay v-if="initialLoading" :message="statusMessage" />
+          <LoadingOverlay v-if="initialLoading" :message="statusMessage" @cancel="cancelCurrentQuery" />
           <div class="left-panel d-flex flex-column">
             <FilterPanel
               v-if="visibleColumns.length > 0"
@@ -187,7 +187,8 @@ import {
   bootstrapMetadata,
   queryData,
   queryCount,
-  transformBbox
+  transformBbox,
+  cancelSentqueries
 } from './db.js';
 import { buildGeoArrowTables, toBinary, findGeoColumn } from '@walkthru-earth/objex-utils';
 import Utils, { checkFileHealth, DEFAULT_PAGE_SIZE } from './utils.js';
@@ -620,7 +621,21 @@ export default {
                 body: [info.detail, info.suggestion].filter(Boolean).join('\n'),
                 config: { timeout: 0, closeOnClick: true }
               };
-            })
+            }),
+          {
+            closeOnClick: false,
+            timeout: 0,
+            buttons: [
+              {
+                text: 'Cancel',
+                action: (t) => {
+                  this.loading = false;
+                  this.$snotify.remove(t.id);
+                  this.cancelCurrentQuery();
+                },
+              }
+            ]
+          }
         );
       });
     },
@@ -1133,6 +1148,24 @@ export default {
           this.conversionToastId = null;
         }
       });
+    },
+
+    async cancelCurrentQuery() {
+      try {
+        this.statusMessage = 'Cancelling query...';
+        await cancelSentqueries();
+      } catch (e) {
+        console.warn('Failed to cancel query:', e.message);
+        this.$snotify.error('Failed to cancel query.', { timeout: 3000 });
+      }
+
+      this.loading = false;
+      if (this.rows.length === 0) {
+        this.reset();
+        this.querySettingsOpen = false;
+        this.loadDialogOpen = true;
+        return;
+      }
     },
 
     cancelConversion() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -25,7 +25,11 @@
           class="content-panels d-flex flex-grow-1"
           style="min-height: 0; position: relative"
         >
-          <LoadingOverlay v-if="initialLoading" :message="statusMessage" @cancel="cancelCurrentQuery" />
+          <LoadingOverlay
+            v-if="initialLoading"
+            :message="statusMessage"
+            @cancel="cancelCurrentQuery"
+          />
           <div class="left-panel d-flex flex-column">
             <FilterPanel
               v-if="visibleColumns.length > 0"
@@ -604,24 +608,26 @@ export default {
     _runTask(message, work) {
       return new Promise((resolve, reject) => {
         this.loading = true;
-        this.$snotify.async(message, () =>
-          work()
-            .then((successMsg) => {
-              this.loading = false;
-              resolve();
-              return { body: successMsg, config: { timeout: 4000 } };
-            })
-            .catch((err) => {
-              this.loading = false;
-              console.error(err);
-              const info = Utils.friendlyError(err);
-              reject(err);
-              throw {
-                title: info.title,
-                body: [info.detail, info.suggestion].filter(Boolean).join('\n'),
-                config: { timeout: 0, closeOnClick: true }
-              };
-            }),
+        this.$snotify.async(
+          message,
+          () =>
+            work()
+              .then((successMsg) => {
+                this.loading = false;
+                resolve();
+                return { body: successMsg, config: { timeout: 4000 } };
+              })
+              .catch((err) => {
+                this.loading = false;
+                console.error(err);
+                const info = Utils.friendlyError(err);
+                reject(err);
+                throw {
+                  title: info.title,
+                  body: [info.detail, info.suggestion].filter(Boolean).join('\n'),
+                  config: { timeout: 0, closeOnClick: true }
+                };
+              }),
           {
             closeOnClick: false,
             timeout: 0,
@@ -632,7 +638,7 @@ export default {
                   this.loading = false;
                   this.$snotify.remove(t.id);
                   this.cancelCurrentQuery();
-                },
+                }
               }
             ]
           }

--- a/src/components/LoadingOverlay.vue
+++ b/src/components/LoadingOverlay.vue
@@ -3,6 +3,10 @@
     <div class="loading-content">
       <v-progress-circular indeterminate color="primary" size="48" width="4" />
       <p v-if="message" class="text-body-2 text-grey-darken-1 mt-4">{{ message }}</p>
+
+      <v-btn size="small" variant="outlined" class="mt-4" @click="cancel">
+        Cancel
+      </v-btn>
     </div>
   </div>
 </template>
@@ -11,7 +15,13 @@
 export default {
   name: 'LoadingOverlay',
   props: {
-    message: { type: String, default: '' }
+    message: { type: String, default: '' },
+  },
+  emits: ['cancel'],
+  methods: {
+    cancel() {
+      this.$emit('cancel');
+    }
   }
 };
 </script>

--- a/src/components/LoadingOverlay.vue
+++ b/src/components/LoadingOverlay.vue
@@ -4,9 +4,7 @@
       <v-progress-circular indeterminate color="primary" size="48" width="4" />
       <p v-if="message" class="text-body-2 text-grey-darken-1 mt-4">{{ message }}</p>
 
-      <v-btn size="small" variant="outlined" class="mt-4" @click="cancel">
-        Cancel
-      </v-btn>
+      <v-btn size="small" variant="outlined" class="mt-4" @click="cancel"> Cancel </v-btn>
     </div>
   </div>
 </template>
@@ -15,7 +13,7 @@
 export default {
   name: 'LoadingOverlay',
   props: {
-    message: { type: String, default: '' },
+    message: { type: String, default: '' }
   },
   emits: ['cancel'],
   methods: {

--- a/src/converter.worker.js
+++ b/src/converter.worker.js
@@ -53,13 +53,6 @@ async function init() {
     }
     _conn = await _db.connect();
 
-    // Preload coordinate systems before spatial (DuckDB-WASM PROJ init quirk).
-    try {
-      await _conn.query(`SELECT * FROM duckdb_coordinate_systems()`);
-    } catch {
-      /* ignore */
-    }
-
     status('Loading extensions...');
     try {
       await _conn.query(`INSTALL httpfs`);

--- a/src/db.js
+++ b/src/db.js
@@ -7,11 +7,14 @@
  * All WASM/worker assets are bundled locally — no external CDN dependency at runtime.
  */
 
+import * as arrow from 'apache-arrow';
+
 /** Resolve a Vite asset URL to an absolute HTTP URL for DuckDB's LOAD command. */
 const absExtUrl = (url) => new URL(url, location.href).href;
 
 let _db = null;
 let _conn = null;
+let _worker = null;
 let _initPromise = null;
 let _lastProgressMsg = null;
 
@@ -72,10 +75,10 @@ export async function initDB(onProgress) {
 
     _emitProgress('Starting DuckDB...');
 
-    let worker = new Worker(mainWorker);
+    _worker = new Worker(mainWorker);
 
     const logger = new duckdb.ConsoleLogger(duckdb.LogLevel.WARNING);
-    _db = new duckdb.AsyncDuckDB(logger, worker);
+    _db = new duckdb.AsyncDuckDB(logger, _worker);
 
     await _db.instantiate(mainModule);
 
@@ -127,8 +130,12 @@ export async function getConnection() {
  * Execute a SQL query and return an Arrow Table.
  */
 export async function query(sql) {
+  console.log('Executing query:', sql);
   const conn = await getConnection();
-  return await conn.query(sql);
+  const result = await conn.send(sql)
+  const allResults = await result.readAll();
+
+  return new arrow.Table(allResults);
 }
 
 /**
@@ -156,6 +163,16 @@ export async function dropFile(name) {
  */
 export function escapeSource(source) {
   return source.replace(/'/g, "''");
+}
+
+export async function cancelSentqueries() {
+  if (_conn) {
+    try {
+      await _conn.cancelSent();
+    } catch {
+      /* ignore */
+    }
+  }
 }
 
 /**

--- a/src/db.js
+++ b/src/db.js
@@ -17,6 +17,7 @@ let _conn = null;
 let _worker = null;
 let _initPromise = null;
 let _lastProgressMsg = null;
+let _currentReader = null;
 
 // Cache: source → { geoColumn → boolean } for isGeometryType results.
 // Avoids repeated DESCRIBE queries on every queryData/queryCount call.
@@ -88,15 +89,6 @@ export async function initDB(onProgress) {
     _emitProgress('Connection to database...');
     _conn = await _db.connect();
 
-    // Workaround for DuckDB-WASM PROJ initialization timing issue (#2199):
-    // Load coordinate system data BEFORE loading spatial extension.
-    _emitProgress('Preloading coordinate systems...');
-    try {
-      await _conn.query(`SELECT * FROM duckdb_coordinate_systems()`);
-    } catch (e) {
-      throw new Error('Failed to load coordinate reference systems', { cause: e });
-    }
-
     const loadExtension = async (name, url, unavailableMsg) => {
       _emitProgress(`Loading ${name} extension...`);
       try {
@@ -130,12 +122,16 @@ export async function getConnection() {
  * Execute a SQL query and return an Arrow Table.
  */
 export async function query(sql) {
-  console.log('Executing query:', sql);
   const conn = await getConnection();
-  const result = await conn.send(sql)
-  const allResults = await result.readAll();
-
-  return new arrow.Table(allResults);
+  const reader = await conn.send(sql);
+  _currentReader = reader;
+  try {
+    const allResults = await reader.readAll();
+    return new arrow.Table(allResults);
+  } finally {
+    _currentReader = null;
+    await reader.cancel(); // Close the Arrow stream reader; safe after readAll() and during cancellation.
+  }
 }
 
 /**
@@ -166,6 +162,15 @@ export function escapeSource(source) {
 }
 
 export async function cancelSentqueries() {
+  const reader = _currentReader;
+  if (reader) {
+    _currentReader = null;
+    try {
+      await reader.cancel();
+    } catch {
+      /* ignore */
+    }
+  }
   if (_conn) {
     try {
       await _conn.cancelSent();
@@ -282,7 +287,7 @@ export async function bootstrapMetadata(source, onProgress = () => {}) {
   let totalRows = -1;
   try {
     const fileResult = await query(
-      `SELECT * EXCLUDE (column_orders,footer_signing_key_metadata) FROM parquet_file_metadata('${escaped}')`
+      `SELECT * EXCLUDE (footer_signing_key_metadata) FROM parquet_file_metadata('${escaped}')`
     );
     const row = fileResult.toArray()[0];
     fileInfo = {};


### PR DESCRIPTION
This is trying to implement aborting requests.

Usage of send works only in v1.32.0.

I'm not sure why we were on a dev version, but it seems https://github.com/duckdb/duckdb-wasm/issues/2199 was the issue we updated for. At the same time, with the older version we don't need the duckdb_coordinate_systems() call anymore.

I'm not sure whether anything breaks by downgrading to v1.32.0. Ideally duckdb-wasm would release a stable 1.34.0 that doesn't have any of the issues...

Keeping this in draft for now to wait for upstream changes.