### PR TITLE
Chore/update geoarrow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "geoparquet-viewer",
       "version": "1.0.0",
       "dependencies": {
-        "@deck.gl/core": "^9.3.0",
-        "@deck.gl/layers": "^9.3.0",
-        "@deck.gl/mapbox": "^9.3.0",
+        "@deck.gl/core": "^9.3.2",
+        "@deck.gl/layers": "^9.3.2",
+        "@deck.gl/mapbox": "^9.3.2",
         "@duckdb/duckdb-wasm": "^1.33.1-dev45.0",
         "@geoarrow/deck.gl-geoarrow": "^0.4.1",
         "@mdi/font": "^7.4.47",
@@ -103,17 +103,17 @@
       }
     },
     "node_modules/@deck.gl/core": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.3.1.tgz",
-      "integrity": "sha512-uixmBJhaAAgjzppcJ+0Hh2R1BYvFHvCHFReXN93iQxQoNB3VCC03pGEhZ0hrW7hcVLC8ExCUrg8VRJW60wXzcA==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.3.2.tgz",
+      "integrity": "sha512-32Va3np0Zdlz/LBNtDWCs4EkKqdHmXcbGmVp4+7i1Cpdza8y8CFmJs2VPOmSX1fwHvNCGkAZV/SFZOfDb2INsg==",
       "license": "MIT",
       "dependencies": {
         "@loaders.gl/core": "^4.4.1",
         "@loaders.gl/images": "^4.4.1",
-        "@luma.gl/core": "^9.3.2",
-        "@luma.gl/engine": "^9.3.2",
-        "@luma.gl/shadertools": "^9.3.2",
-        "@luma.gl/webgl": "^9.3.2",
+        "@luma.gl/core": "^9.3.3",
+        "@luma.gl/engine": "^9.3.3",
+        "@luma.gl/shadertools": "^9.3.3",
+        "@luma.gl/webgl": "^9.3.3",
         "@math.gl/core": "^4.1.0",
         "@math.gl/sun": "^4.1.0",
         "@math.gl/types": "^4.1.0",
@@ -179,14 +179,14 @@
       }
     },
     "node_modules/@deck.gl/layers": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.3.1.tgz",
-      "integrity": "sha512-gUT/UMrmSCYsJCyv78qjHdeZVnqDexX61WxNP3dUa7ZplXiG3NxZvjhS0PYeBLritOtCJSv3b13vR2ka+j49ZQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.3.2.tgz",
+      "integrity": "sha512-TeVfhQ/cQU1oTlTn16mCp7268d1uBJ6dwfgmKXThe2TzW9hql3iJaxbYTKg2phDg5YSiGmeEOpXbeBh59jyUcA==",
       "license": "MIT",
       "dependencies": {
         "@loaders.gl/images": "^4.4.1",
         "@loaders.gl/schema": "^4.4.1",
-        "@luma.gl/shadertools": "^9.3.2",
+        "@luma.gl/shadertools": "^9.3.3",
         "@mapbox/tiny-sdf": "^2.0.5",
         "@math.gl/core": "^4.1.0",
         "@math.gl/polygon": "^4.1.0",
@@ -196,21 +196,21 @@
       "peerDependencies": {
         "@deck.gl/core": "~9.3.0",
         "@loaders.gl/core": "^4.4.1",
-        "@luma.gl/core": "~9.3.2",
-        "@luma.gl/engine": "~9.3.2"
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3"
       }
     },
     "node_modules/@deck.gl/mapbox": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-9.3.1.tgz",
-      "integrity": "sha512-4SgpWMeZiqiZEiz9yPdr89cVRL8HFcvXLxXUA0ExhMreUdNuK/j2OIQHPhw6vp1xCFbJEEqRelQ0pJYkhGDkYw==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-9.3.2.tgz",
+      "integrity": "sha512-+T9pJwsOXwjUxyGN6oiBMfIs28VtDIG1V1Rqz4qqn4TjjNEFFw+xO0olJIg8FO5IAqw2OtePdsrMj0tX8tHdGQ==",
       "license": "MIT",
       "dependencies": {
         "@math.gl/web-mercator": "^4.1.0"
       },
       "peerDependencies": {
         "@deck.gl/core": "~9.3.0",
-        "@luma.gl/core": "~9.3.2",
+        "@luma.gl/core": "~9.3.3",
         "@math.gl/web-mercator": "^4.1.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@deck.gl/layers": "^9.3.0",
         "@deck.gl/mapbox": "^9.3.0",
         "@duckdb/duckdb-wasm": "^1.33.1-dev45.0",
-        "@geoarrow/deck.gl-layers": "^0.3.2",
+        "@geoarrow/deck.gl-geoarrow": "^0.4.1",
         "@mdi/font": "^7.4.47",
         "@theace0296/vue-snotify": "^4.0.4",
         "@vueuse/core": "^14.2.1",
@@ -70,16 +70,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/types": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
@@ -94,13 +84,13 @@
       }
     },
     "node_modules/@deck.gl/aggregation-layers": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.3.1.tgz",
-      "integrity": "sha512-Aikrnrft79kbWjMNENxKF+Gg4JO0y4wkF8fokrr/tXRKaNIy/WV9yPXu3sNKzwZliucV/uJJtAE7DxCtyJl6uw==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.3.2.tgz",
+      "integrity": "sha512-aOzCmJHPYM95aFEW7s3lyFibTSP+T/fYqCP2RxHyi/IxQwROwJTDrKyn/qPw5GvzZOIgFVxlR1Qc9RY8qYRFBw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@luma.gl/shadertools": "^9.3.2",
+        "@luma.gl/shadertools": "^9.3.3",
         "@math.gl/core": "^4.1.0",
         "@math.gl/web-mercator": "^4.1.0",
         "d3-hexbin": "^0.2.1"
@@ -108,8 +98,8 @@
       "peerDependencies": {
         "@deck.gl/core": "~9.3.0",
         "@deck.gl/layers": "~9.3.0",
-        "@luma.gl/core": "~9.3.2",
-        "@luma.gl/engine": "~9.3.2"
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3"
       }
     },
     "node_modules/@deck.gl/core": {
@@ -137,26 +127,26 @@
       }
     },
     "node_modules/@deck.gl/extensions": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.3.1.tgz",
-      "integrity": "sha512-XTJgC8pnS9zuiFRhlPTQnE0WKMuJCnZ4xdXmd9TMJRH58Z0DKaKHpc3j32heFKLoRHo3G/TKlCoP/my5tgYT+Q==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.3.2.tgz",
+      "integrity": "sha512-P2gPCCmGC5R6HRB3Mv3JraDnsSpvStjFFUGKxW810SXmo2eTft/5xpvliiyJeFGDjqttwo8V4Qk6oD3BNVGvRw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@luma.gl/shadertools": "^9.3.2",
-        "@luma.gl/webgl": "^9.3.2",
+        "@luma.gl/shadertools": "^9.3.3",
+        "@luma.gl/webgl": "^9.3.3",
         "@math.gl/core": "^4.1.0"
       },
       "peerDependencies": {
         "@deck.gl/core": "~9.3.0",
-        "@luma.gl/core": "~9.3.2",
-        "@luma.gl/engine": "~9.3.2"
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3"
       }
     },
     "node_modules/@deck.gl/geo-layers": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.3.1.tgz",
-      "integrity": "sha512-MyQs/mb/+Kp3Y+HARClQxnvCYH0MjkXR+QAyalMdM/bJoVox8sw7k2WkHyzubEH5uKFWX6F509XueC86SrVrZw==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.3.2.tgz",
+      "integrity": "sha512-3sndOyq5A3b2DMCBWFCeX9/QkBSp5MD8EUD3eu4hHfCDV4IrbJHtxE/pv60J848Yz8D5u7ftUqXf9gLWnEeBeg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -168,8 +158,8 @@
         "@loaders.gl/terrain": "^4.4.1",
         "@loaders.gl/tiles": "^4.4.1",
         "@loaders.gl/wms": "^4.4.1",
-        "@luma.gl/gltf": "^9.3.2",
-        "@luma.gl/shadertools": "^9.3.2",
+        "@luma.gl/gltf": "^9.3.3",
+        "@luma.gl/shadertools": "^9.3.3",
         "@math.gl/core": "^4.1.0",
         "@math.gl/culling": "^4.1.0",
         "@math.gl/web-mercator": "^4.1.0",
@@ -184,8 +174,8 @@
         "@deck.gl/layers": "~9.3.0",
         "@deck.gl/mesh-layers": "~9.3.0",
         "@loaders.gl/core": "^4.4.1",
-        "@luma.gl/core": "~9.3.2",
-        "@luma.gl/engine": "~9.3.2"
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3"
       }
     },
     "node_modules/@deck.gl/layers": {
@@ -210,15 +200,6 @@
         "@luma.gl/engine": "~9.3.2"
       }
     },
-    "node_modules/@deck.gl/layers/node_modules/@math.gl/polygon": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-4.1.0.tgz",
-      "integrity": "sha512-YA/9PzaCRHbIP5/0E9uTYrqe+jsYTQoqoDWhf6/b0Ixz8bPZBaGDEafLg3z7ffBomZLacUty9U3TlPjqMtzPjA==",
-      "license": "MIT",
-      "dependencies": {
-        "@math.gl/core": "4.1.0"
-      }
-    },
     "node_modules/@deck.gl/mapbox": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-9.3.1.tgz",
@@ -234,23 +215,23 @@
       }
     },
     "node_modules/@deck.gl/mesh-layers": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.3.1.tgz",
-      "integrity": "sha512-SvLviM1bYcdFZiX2OZ4Hf0zC44brm1gLbP3j92w/Vt+Mp5O0UHGuzKNPA4kdyL1wAuRfKXXfoJZzVg1/YNbT4g==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.3.2.tgz",
+      "integrity": "sha512-9KeEnEx8PYalFPq/jSb1983QtjwZeuz64OfHH8I2VOB3eOhtRDxaTAaelbkVkD3E9HqlU2dD6f9huYsuv1WZfw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@loaders.gl/gltf": "^4.4.1",
         "@loaders.gl/schema": "^4.4.1",
-        "@luma.gl/gltf": "^9.3.2",
-        "@luma.gl/shadertools": "^9.3.2"
+        "@luma.gl/gltf": "^9.3.3",
+        "@luma.gl/shadertools": "^9.3.3"
       },
       "peerDependencies": {
         "@deck.gl/core": "~9.3.0",
-        "@luma.gl/core": "~9.3.2",
-        "@luma.gl/engine": "~9.3.2",
-        "@luma.gl/gltf": "~9.3.2",
-        "@luma.gl/shadertools": "~9.3.2"
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3",
+        "@luma.gl/gltf": "~9.3.3",
+        "@luma.gl/shadertools": "~9.3.3"
       }
     },
     "node_modules/@duckdb/duckdb-wasm": {
@@ -508,26 +489,21 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
-    "node_modules/@geoarrow/deck.gl-layers": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@geoarrow/deck.gl-layers/-/deck.gl-layers-0.3.2.tgz",
-      "integrity": "sha512-GWepG0iNSU1X1rdkcuYIR6ZQaUJ67XesLjzk2gUxvbxuQgKZBFra7goOh53ziyMercy0hVRrXEqE0M+DJmYDDA==",
-      "deprecated": "This package has been renamed to @geoarrow/deck.gl-geoarrow",
+    "node_modules/@geoarrow/deck.gl-geoarrow": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@geoarrow/deck.gl-geoarrow/-/deck.gl-geoarrow-0.4.1.tgz",
+      "integrity": "sha512-WYRuN1UnDkudOivyXwa6vPRCfiZmfax2NvQf99vbGyrN1EiY+UzuB2XHdZvEGUScUg2xo30iei91CvwTetH6AA==",
       "license": "MIT",
-      "workspaces": [
-        ".",
-        "examples/*"
-      ],
       "dependencies": {
         "@geoarrow/geoarrow-js": "^0.3.0",
         "threads": "^1.7.0"
       },
       "peerDependencies": {
-        "@deck.gl/aggregation-layers": "^9.0.12",
-        "@deck.gl/core": "^9.0.12",
-        "@deck.gl/geo-layers": "^9.0.12",
-        "@deck.gl/layers": "^9.0.12",
-        "@math.gl/polygon": "^3.6.2",
+        "@deck.gl/aggregation-layers": "^9.0.0",
+        "@deck.gl/core": "^9.0.0",
+        "@deck.gl/geo-layers": "^9.0.0",
+        "@deck.gl/layers": "^9.0.0",
+        "@math.gl/polygon": "^4.1.0",
         "apache-arrow": ">=15"
       }
     },
@@ -543,15 +519,6 @@
       },
       "peerDependencies": {
         "apache-arrow": ">=15"
-      }
-    },
-    "node_modules/@geoarrow/geoarrow-js/node_modules/@math.gl/polygon": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-4.1.0.tgz",
-      "integrity": "sha512-YA/9PzaCRHbIP5/0E9uTYrqe+jsYTQoqoDWhf6/b0Ixz8bPZBaGDEafLg3z7ffBomZLacUty9U3TlPjqMtzPjA==",
-      "license": "MIT",
-      "dependencies": {
-        "@math.gl/core": "4.1.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -627,27 +594,61 @@
       "license": "MIT"
     },
     "node_modules/@loaders.gl/3d-tiles": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-4.4.1.tgz",
-      "integrity": "sha512-837MynN5/lqVbuZcqdxFb0CMfT8v0yRlX7TUFKIBdmkS7AeRRrgcrB+XKblrkdZINUcxOs2N/YLVkwC9wLH1Uw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-4.4.2.tgz",
+      "integrity": "sha512-rf2R7x/+t41hQpaQ3iKofooE6unZ0+sGlYUXBo7lYFEnoMmalzrOI6jCs+CV96TALMPQcpfPa566XWF74XkaBQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@loaders.gl/compression": "4.4.1",
-        "@loaders.gl/crypto": "4.4.1",
-        "@loaders.gl/draco": "4.4.1",
-        "@loaders.gl/gltf": "4.4.1",
-        "@loaders.gl/images": "4.4.1",
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/math": "4.4.1",
-        "@loaders.gl/tiles": "4.4.1",
-        "@loaders.gl/zip": "4.4.1",
+        "@loaders.gl/compression": "4.4.2",
+        "@loaders.gl/crypto": "4.4.2",
+        "@loaders.gl/draco": "4.4.2",
+        "@loaders.gl/gltf": "4.4.2",
+        "@loaders.gl/images": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/math": "4.4.2",
+        "@loaders.gl/tiles": "4.4.2",
+        "@loaders.gl/zip": "4.4.2",
         "@math.gl/core": "^4.1.0",
         "@math.gl/culling": "^4.1.0",
         "@math.gl/geospatial": "^4.1.0",
         "@probe.gl/log": "^4.1.1",
         "long": "^5.2.1"
       },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/3d-tiles/node_modules/@loaders.gl/loader-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.2.tgz",
+      "integrity": "sha512-kqwBbyRC7rrQVsnJyKeoaig9hxaa5oj91OKqWm27HPuVn4q2dD67SEhiG0ND62eRp0tLY6jTqEcI5kDzHBZ6MA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
+      }
+    },
+    "node_modules/@loaders.gl/3d-tiles/node_modules/@loaders.gl/schema": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.2.tgz",
+      "integrity": "sha512-mJTZehTHIFl8ed+03nebuPAMnLP8Yp00DKTzCnKT2HNy/uV4+Sw+GrGIuhPHGU8tdQmtBXRURGM2ZxUAxMfGKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/3d-tiles/node_modules/@loaders.gl/worker-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.2.tgz",
+      "integrity": "sha512-oiZ0SoC1QKrOkhYPlVZ6Q06CtmuFRyZw2rwzmT08ZyaGtOArIJHDjlhxzwWiv+6fdws47Ub5uIGsdI1Ab1xYsA==",
+      "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@loaders.gl/core": "~4.4.0"
       }
@@ -660,14 +661,14 @@
       "peer": true
     },
     "node_modules/@loaders.gl/compression": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/compression/-/compression-4.4.1.tgz",
-      "integrity": "sha512-MKtGbqHBH7xRVFKyB3E9xRqRMwNW8H72OKpUBDdFwP+hQ0mjHZuud0GeYm5pP50+7o3J2PrES06kHTwT4fg7oQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/compression/-/compression-4.4.2.tgz",
+      "integrity": "sha512-/LzblCXn6wOg7ca2zkUOTO0zhjjaPAOqlLp4/kwd57v7KZU8M8aKUNlU1DAuWKW9p/+TpGsLKwDqOCO+hjrOnQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/worker-utils": "4.4.1",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
         "@types/pako": "^1.0.1",
         "fflate": "0.7.4",
         "pako": "1.0.11",
@@ -679,6 +680,40 @@
         "lz4js": "^0.2.0",
         "zstd-codec": "^0.1"
       },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/compression/node_modules/@loaders.gl/loader-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.2.tgz",
+      "integrity": "sha512-kqwBbyRC7rrQVsnJyKeoaig9hxaa5oj91OKqWm27HPuVn4q2dD67SEhiG0ND62eRp0tLY6jTqEcI5kDzHBZ6MA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
+      }
+    },
+    "node_modules/@loaders.gl/compression/node_modules/@loaders.gl/schema": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.2.tgz",
+      "integrity": "sha512-mJTZehTHIFl8ed+03nebuPAMnLP8Yp00DKTzCnKT2HNy/uV4+Sw+GrGIuhPHGU8tdQmtBXRURGM2ZxUAxMfGKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/compression/node_modules/@loaders.gl/worker-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.2.tgz",
+      "integrity": "sha512-oiZ0SoC1QKrOkhYPlVZ6Q06CtmuFRyZw2rwzmT08ZyaGtOArIJHDjlhxzwWiv+6fdws47Ub5uIGsdI1Ab1xYsA==",
+      "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@loaders.gl/core": "~4.4.0"
       }
@@ -697,41 +732,124 @@
       }
     },
     "node_modules/@loaders.gl/crypto": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/crypto/-/crypto-4.4.1.tgz",
-      "integrity": "sha512-ORhS9GSYr9uVTU4I2Taa46XBgPPG+nKErKcyDGIXov3gs0EtgMqs8nU4epuLbsJN3+du6FkQaILyGSZlTxbA7Q==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/crypto/-/crypto-4.4.2.tgz",
+      "integrity": "sha512-3QQxNFmCeznMIsY/ZD4pYO4SvS4i3nq5aJJ993DEIZVB1i0z19OmyJu4TSovvirXXrNWPQRJFPUUwdPxol9wLA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/worker-utils": "4.4.1",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
         "@types/crypto-js": "^4.0.2"
       },
       "peerDependencies": {
         "@loaders.gl/core": "~4.4.0"
       }
     },
-    "node_modules/@loaders.gl/draco": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-4.4.1.tgz",
-      "integrity": "sha512-EcapVlkP8Pz53VKg9pYRQUzqm9jH+A+7vGE1kV8nkv63lN8/qtFzBSWMiC6IX1CwxjKJDEINU9Sh8YB1AfMwbQ==",
+    "node_modules/@loaders.gl/crypto/node_modules/@loaders.gl/loader-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.2.tgz",
+      "integrity": "sha512-kqwBbyRC7rrQVsnJyKeoaig9hxaa5oj91OKqWm27HPuVn4q2dD67SEhiG0ND62eRp0tLY6jTqEcI5kDzHBZ6MA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/schema": "4.4.1",
-        "@loaders.gl/schema-utils": "4.4.1",
-        "@loaders.gl/worker-utils": "4.4.1",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
+      }
+    },
+    "node_modules/@loaders.gl/crypto/node_modules/@loaders.gl/schema": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.2.tgz",
+      "integrity": "sha512-mJTZehTHIFl8ed+03nebuPAMnLP8Yp00DKTzCnKT2HNy/uV4+Sw+GrGIuhPHGU8tdQmtBXRURGM2ZxUAxMfGKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/crypto/node_modules/@loaders.gl/worker-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.2.tgz",
+      "integrity": "sha512-oiZ0SoC1QKrOkhYPlVZ6Q06CtmuFRyZw2rwzmT08ZyaGtOArIJHDjlhxzwWiv+6fdws47Ub5uIGsdI1Ab1xYsA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/draco": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-4.4.2.tgz",
+      "integrity": "sha512-UByWIt/yhxMFBIlyoqJYaj0rnTz/wwDWbI4CVQc/MzbLZW7NtUkDyYDcjbjE2SBWpu6Ef4ryojGd/NWIA3Yknw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/schema-utils": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
         "draco3d": "1.5.7"
       },
       "peerDependencies": {
         "@loaders.gl/core": "~4.4.0"
       }
     },
+    "node_modules/@loaders.gl/draco/node_modules/@loaders.gl/loader-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.2.tgz",
+      "integrity": "sha512-kqwBbyRC7rrQVsnJyKeoaig9hxaa5oj91OKqWm27HPuVn4q2dD67SEhiG0ND62eRp0tLY6jTqEcI5kDzHBZ6MA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
+      }
+    },
+    "node_modules/@loaders.gl/draco/node_modules/@loaders.gl/schema": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.2.tgz",
+      "integrity": "sha512-mJTZehTHIFl8ed+03nebuPAMnLP8Yp00DKTzCnKT2HNy/uV4+Sw+GrGIuhPHGU8tdQmtBXRURGM2ZxUAxMfGKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/draco/node_modules/@loaders.gl/schema-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema-utils/-/schema-utils-4.4.2.tgz",
+      "integrity": "sha512-yYYRD/POBEO72rhIyLASrqKUUhfIOQuFk/fgInN6Td2qvFgsHbo5UaCM4sTqVUWwNxNvXDQi8ezpbnCa/yi+OQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/schema": "4.4.2",
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/draco/node_modules/@loaders.gl/worker-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.2.tgz",
+      "integrity": "sha512-oiZ0SoC1QKrOkhYPlVZ6Q06CtmuFRyZw2rwzmT08ZyaGtOArIJHDjlhxzwWiv+6fdws47Ub5uIGsdI1Ab1xYsA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
     "node_modules/@loaders.gl/geoarrow": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/geoarrow/-/geoarrow-4.4.1.tgz",
-      "integrity": "sha512-d9+AxsNpdJzilgHTFnyycoIocp4b+iEX3bbCCAEdUm/7eZbOdM7sFcgLLiGVTehtGnOUOICskjrzT27gqmzDqg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/geoarrow/-/geoarrow-4.4.2.tgz",
+      "integrity": "sha512-FGCtUsvTwdxiNqS8cEtys1FdM/m6pwMzvNEa32sHfrI4Si465Oa2iJkyu2q/XMgL/vhfE/G3EezpVKZARbCzkw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -742,27 +860,17 @@
         "@loaders.gl/core": "~4.4.0"
       }
     },
-    "node_modules/@loaders.gl/geoarrow/node_modules/@math.gl/polygon": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-4.1.0.tgz",
-      "integrity": "sha512-YA/9PzaCRHbIP5/0E9uTYrqe+jsYTQoqoDWhf6/b0Ixz8bPZBaGDEafLg3z7ffBomZLacUty9U3TlPjqMtzPjA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@math.gl/core": "4.1.0"
-      }
-    },
     "node_modules/@loaders.gl/gis": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-4.4.1.tgz",
-      "integrity": "sha512-M9Z9jXwye4SjlD1hAFJwE3+eZiN1lprwlSkWIo7R642kN5r3R60M9fqBD1mvCTBj96FPmbsyOm1eYKS0XCpKxQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-4.4.2.tgz",
+      "integrity": "sha512-VMs1XcqUCqLczfySsI9VA/L3WDuuNRPqVoHcXU3FZuSe49x++gtwmxF1TEhJCaQINk0CkCOnxBbKOz3I9M1e3w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@loaders.gl/geoarrow": "4.4.1",
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/schema": "4.4.1",
-        "@loaders.gl/schema-utils": "4.4.1",
+        "@loaders.gl/geoarrow": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/schema-utils": "4.4.2",
         "@mapbox/vector-tile": "^1.3.1",
         "@math.gl/polygon": "^4.1.0",
         "pbf": "^3.2.1"
@@ -771,42 +879,146 @@
         "@loaders.gl/core": "~4.4.0"
       }
     },
-    "node_modules/@loaders.gl/gis/node_modules/@math.gl/polygon": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-4.1.0.tgz",
-      "integrity": "sha512-YA/9PzaCRHbIP5/0E9uTYrqe+jsYTQoqoDWhf6/b0Ixz8bPZBaGDEafLg3z7ffBomZLacUty9U3TlPjqMtzPjA==",
+    "node_modules/@loaders.gl/gis/node_modules/@loaders.gl/loader-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.2.tgz",
+      "integrity": "sha512-kqwBbyRC7rrQVsnJyKeoaig9hxaa5oj91OKqWm27HPuVn4q2dD67SEhiG0ND62eRp0tLY6jTqEcI5kDzHBZ6MA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@math.gl/core": "4.1.0"
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
+      }
+    },
+    "node_modules/@loaders.gl/gis/node_modules/@loaders.gl/schema": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.2.tgz",
+      "integrity": "sha512-mJTZehTHIFl8ed+03nebuPAMnLP8Yp00DKTzCnKT2HNy/uV4+Sw+GrGIuhPHGU8tdQmtBXRURGM2ZxUAxMfGKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/gis/node_modules/@loaders.gl/schema-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema-utils/-/schema-utils-4.4.2.tgz",
+      "integrity": "sha512-yYYRD/POBEO72rhIyLASrqKUUhfIOQuFk/fgInN6Td2qvFgsHbo5UaCM4sTqVUWwNxNvXDQi8ezpbnCa/yi+OQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/schema": "4.4.2",
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/gis/node_modules/@loaders.gl/worker-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.2.tgz",
+      "integrity": "sha512-oiZ0SoC1QKrOkhYPlVZ6Q06CtmuFRyZw2rwzmT08ZyaGtOArIJHDjlhxzwWiv+6fdws47Ub5uIGsdI1Ab1xYsA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/gltf": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-4.4.1.tgz",
-      "integrity": "sha512-9ESHEm3YoMgsQh8QS1N99uwA+cij6p6xhCmZnHX4rQnqHm0jvE5RAHlGV1D/Xjvr4PR8IiXaBn/QDl/qdGIxkw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-4.4.2.tgz",
+      "integrity": "sha512-aBvI7P/1GxePdHIvuyTM4A8yt3F5ph4dq0mkyJHmEjBl1Cwh3mDZJI1JSlZAFVilTZ6NxJZOiHUYWe1pBloVvw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@loaders.gl/draco": "4.4.1",
-        "@loaders.gl/images": "4.4.1",
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/schema": "4.4.1",
-        "@loaders.gl/textures": "4.4.1",
+        "@loaders.gl/draco": "4.4.2",
+        "@loaders.gl/images": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/textures": "4.4.2",
         "@math.gl/core": "^4.1.0"
       },
       "peerDependencies": {
         "@loaders.gl/core": "~4.4.0"
       }
     },
+    "node_modules/@loaders.gl/gltf/node_modules/@loaders.gl/loader-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.2.tgz",
+      "integrity": "sha512-kqwBbyRC7rrQVsnJyKeoaig9hxaa5oj91OKqWm27HPuVn4q2dD67SEhiG0ND62eRp0tLY6jTqEcI5kDzHBZ6MA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
+      }
+    },
+    "node_modules/@loaders.gl/gltf/node_modules/@loaders.gl/schema": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.2.tgz",
+      "integrity": "sha512-mJTZehTHIFl8ed+03nebuPAMnLP8Yp00DKTzCnKT2HNy/uV4+Sw+GrGIuhPHGU8tdQmtBXRURGM2ZxUAxMfGKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/gltf/node_modules/@loaders.gl/worker-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.2.tgz",
+      "integrity": "sha512-oiZ0SoC1QKrOkhYPlVZ6Q06CtmuFRyZw2rwzmT08ZyaGtOArIJHDjlhxzwWiv+6fdws47Ub5uIGsdI1Ab1xYsA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
     "node_modules/@loaders.gl/images": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-4.4.1.tgz",
-      "integrity": "sha512-v9A4BliEKGxhLuEbh0Ke8ElUlp04KxpKIknUtXXWoEaszAMTSrHI3YhaL/JdRlHraC1VUF/sjzbSBFkKh7nxJg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-4.4.2.tgz",
+      "integrity": "sha512-b+1keNvPlyLniWtX4ZaThz2dF2aohi8Q+OEsDF2hJNZYyZJOqP9b/72UhlVk+inxTJfTLRBNARs2TJ2ssBlelg==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.4.1"
+        "@loaders.gl/loader-utils": "4.4.2"
       },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/images/node_modules/@loaders.gl/loader-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.2.tgz",
+      "integrity": "sha512-kqwBbyRC7rrQVsnJyKeoaig9hxaa5oj91OKqWm27HPuVn4q2dD67SEhiG0ND62eRp0tLY6jTqEcI5kDzHBZ6MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
+      }
+    },
+    "node_modules/@loaders.gl/images/node_modules/@loaders.gl/schema": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.2.tgz",
+      "integrity": "sha512-mJTZehTHIFl8ed+03nebuPAMnLP8Yp00DKTzCnKT2HNy/uV4+Sw+GrGIuhPHGU8tdQmtBXRURGM2ZxUAxMfGKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/images/node_modules/@loaders.gl/worker-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.2.tgz",
+      "integrity": "sha512-oiZ0SoC1QKrOkhYPlVZ6Q06CtmuFRyZw2rwzmT08ZyaGtOArIJHDjlhxzwWiv+6fdws47Ub5uIGsdI1Ab1xYsA==",
+      "license": "MIT",
       "peerDependencies": {
         "@loaders.gl/core": "~4.4.0"
       }
@@ -824,9 +1036,9 @@
       }
     },
     "node_modules/@loaders.gl/math": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-4.4.1.tgz",
-      "integrity": "sha512-xenAPOAUd7HDlus5V/g4LKVh1l7FpyVRSYXa+g7tBj91xzhRYgLEXSxdrGfRNAFMDOSGC1ITwCGQwlwSX4Mpxw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-4.4.2.tgz",
+      "integrity": "sha512-Pcm1DKrzH3EqC5PkBxQX0oVjmXM3RIm2Gfj0cXQoqly+8c/NBtQrcBA9tl12h2ozZe8Ednue/kockbGsyKAx5A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -837,16 +1049,16 @@
       }
     },
     "node_modules/@loaders.gl/mvt": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-4.4.1.tgz",
-      "integrity": "sha512-ou1Oyec7hcpCQ2onF1FefNXVv1MwPjwUkII6IFrrRZ/f0/ei0b8yc5IVwO4gkhta/Ve/Y+mFcs/GaeQZMOEBOg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-4.4.2.tgz",
+      "integrity": "sha512-yji3TAUofTA3GXvvyemwfrRwbd1ILpv2qe4mRduHdzjJdy2httH1cCKkesavFuLeRQqEuVyhhxYK+aSAbdt9Kg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@loaders.gl/gis": "4.4.1",
-        "@loaders.gl/images": "4.4.1",
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/gis": "4.4.2",
+        "@loaders.gl/images": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
         "@math.gl/polygon": "^4.1.0",
         "@probe.gl/stats": "^4.1.1",
         "pbf": "^3.2.1"
@@ -855,14 +1067,38 @@
         "@loaders.gl/core": "~4.4.0"
       }
     },
-    "node_modules/@loaders.gl/mvt/node_modules/@math.gl/polygon": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-4.1.0.tgz",
-      "integrity": "sha512-YA/9PzaCRHbIP5/0E9uTYrqe+jsYTQoqoDWhf6/b0Ixz8bPZBaGDEafLg3z7ffBomZLacUty9U3TlPjqMtzPjA==",
+    "node_modules/@loaders.gl/mvt/node_modules/@loaders.gl/loader-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.2.tgz",
+      "integrity": "sha512-kqwBbyRC7rrQVsnJyKeoaig9hxaa5oj91OKqWm27HPuVn4q2dD67SEhiG0ND62eRp0tLY6jTqEcI5kDzHBZ6MA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@math.gl/core": "4.1.0"
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
+      }
+    },
+    "node_modules/@loaders.gl/mvt/node_modules/@loaders.gl/schema": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.2.tgz",
+      "integrity": "sha512-mJTZehTHIFl8ed+03nebuPAMnLP8Yp00DKTzCnKT2HNy/uV4+Sw+GrGIuhPHGU8tdQmtBXRURGM2ZxUAxMfGKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/mvt/node_modules/@loaders.gl/worker-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.2.tgz",
+      "integrity": "sha512-oiZ0SoC1QKrOkhYPlVZ6Q06CtmuFRyZw2rwzmT08ZyaGtOArIJHDjlhxzwWiv+6fdws47Ub5uIGsdI1Ab1xYsA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/schema": {
@@ -890,32 +1126,66 @@
       }
     },
     "node_modules/@loaders.gl/terrain": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-4.4.1.tgz",
-      "integrity": "sha512-cBLT+G0HefySTppxqqkMKcN5kfOfIRRx0WDPHa0VHFJw9rbnxoEDhrXvfsXfOATNFFNtcpgQUDqDqhEBp0XvZw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-4.4.2.tgz",
+      "integrity": "sha512-ScE90mhUrIOOf+248+G8bxgg5xfLptE94gVxtYsLysyG8b4Ne2WEb6J2gpvQqmaLz3k9OqgPR7M8F1zI5BVO0w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@loaders.gl/images": "4.4.1",
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/images": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
         "@mapbox/martini": "^0.2.0"
       },
       "peerDependencies": {
         "@loaders.gl/core": "~4.4.0"
       }
     },
-    "node_modules/@loaders.gl/textures": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-4.4.1.tgz",
-      "integrity": "sha512-r1//6sO29GOHso+IvXQ3GrvXZ4cl03VWc34XcnXPn3sAV7O96uRGd5xkyx60lMYAl7Jv7qK/smT3z4Mdxdd4aA==",
+    "node_modules/@loaders.gl/terrain/node_modules/@loaders.gl/loader-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.2.tgz",
+      "integrity": "sha512-kqwBbyRC7rrQVsnJyKeoaig9hxaa5oj91OKqWm27HPuVn4q2dD67SEhiG0ND62eRp0tLY6jTqEcI5kDzHBZ6MA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@loaders.gl/images": "4.4.1",
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/schema": "4.4.1",
-        "@loaders.gl/worker-utils": "4.4.1",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
+      }
+    },
+    "node_modules/@loaders.gl/terrain/node_modules/@loaders.gl/schema": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.2.tgz",
+      "integrity": "sha512-mJTZehTHIFl8ed+03nebuPAMnLP8Yp00DKTzCnKT2HNy/uV4+Sw+GrGIuhPHGU8tdQmtBXRURGM2ZxUAxMfGKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/terrain/node_modules/@loaders.gl/worker-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.2.tgz",
+      "integrity": "sha512-oiZ0SoC1QKrOkhYPlVZ6Q06CtmuFRyZw2rwzmT08ZyaGtOArIJHDjlhxzwWiv+6fdws47Ub5uIGsdI1Ab1xYsA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/textures": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-4.4.2.tgz",
+      "integrity": "sha512-+GKcHEE0GjpuSJ6qbuRsB0CaOSUhJ1epUvhMP5GVK7I6+bwSvG8nqmRRGXFQNmYsbFANwG+wjwKf16wqJwP6vg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/images": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
         "@math.gl/types": "^4.1.0",
         "ktx-parse": "^0.7.0",
         "texture-compressor": "^1.0.2"
@@ -924,15 +1194,49 @@
         "@loaders.gl/core": "~4.4.0"
       }
     },
-    "node_modules/@loaders.gl/tiles": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-4.4.1.tgz",
-      "integrity": "sha512-EbF81/c1oXJocVAKR0rx+vWSOnmBBWWhM7pZpYk6oNUQAJfA99APhiRNstAJiJomAgqAxr7vfnhXHjPZg6osZw==",
+    "node_modules/@loaders.gl/textures/node_modules/@loaders.gl/loader-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.2.tgz",
+      "integrity": "sha512-kqwBbyRC7rrQVsnJyKeoaig9hxaa5oj91OKqWm27HPuVn4q2dD67SEhiG0ND62eRp0tLY6jTqEcI5kDzHBZ6MA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/math": "4.4.1",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
+      }
+    },
+    "node_modules/@loaders.gl/textures/node_modules/@loaders.gl/schema": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.2.tgz",
+      "integrity": "sha512-mJTZehTHIFl8ed+03nebuPAMnLP8Yp00DKTzCnKT2HNy/uV4+Sw+GrGIuhPHGU8tdQmtBXRURGM2ZxUAxMfGKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/textures/node_modules/@loaders.gl/worker-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.2.tgz",
+      "integrity": "sha512-oiZ0SoC1QKrOkhYPlVZ6Q06CtmuFRyZw2rwzmT08ZyaGtOArIJHDjlhxzwWiv+6fdws47Ub5uIGsdI1Ab1xYsA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/tiles": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-4.4.2.tgz",
+      "integrity": "sha512-DHqMC38e6IEzWEDc15GfIKsZT82VZH7ocF79xLRScey0eZfCb3qI5nDLeg5adSBBsHkG3Li0S0PEnwxQmKT3qw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/math": "4.4.2",
         "@math.gl/core": "^4.1.0",
         "@math.gl/culling": "^4.1.0",
         "@math.gl/geospatial": "^4.1.0",
@@ -943,20 +1247,88 @@
         "@loaders.gl/core": "~4.4.0"
       }
     },
-    "node_modules/@loaders.gl/wms": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/wms/-/wms-4.4.1.tgz",
-      "integrity": "sha512-sIaqyHXPuLQnkN2eebvczZYVvapkjA8EZaI8feaPxj4jZk/Hk5EuZzIbxJ4eftLotZwDHd3XzEVIs6YlFOSJ+Q==",
+    "node_modules/@loaders.gl/tiles/node_modules/@loaders.gl/loader-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.2.tgz",
+      "integrity": "sha512-kqwBbyRC7rrQVsnJyKeoaig9hxaa5oj91OKqWm27HPuVn4q2dD67SEhiG0ND62eRp0tLY6jTqEcI5kDzHBZ6MA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@loaders.gl/images": "4.4.1",
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/schema": "4.4.1",
-        "@loaders.gl/xml": "4.4.1",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
+      }
+    },
+    "node_modules/@loaders.gl/tiles/node_modules/@loaders.gl/schema": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.2.tgz",
+      "integrity": "sha512-mJTZehTHIFl8ed+03nebuPAMnLP8Yp00DKTzCnKT2HNy/uV4+Sw+GrGIuhPHGU8tdQmtBXRURGM2ZxUAxMfGKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/tiles/node_modules/@loaders.gl/worker-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.2.tgz",
+      "integrity": "sha512-oiZ0SoC1QKrOkhYPlVZ6Q06CtmuFRyZw2rwzmT08ZyaGtOArIJHDjlhxzwWiv+6fdws47Ub5uIGsdI1Ab1xYsA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/wms": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/wms/-/wms-4.4.2.tgz",
+      "integrity": "sha512-7uhis6fOTHeqRLIU1EPoC1oqeXVk5p1pM136fSqMw0CbVSNj87b0FFMwlJwzwTfL8Vte8GyKrNcDa47PjaT19Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/images": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/xml": "4.4.2",
         "@turf/rewind": "^5.1.5",
         "deep-strict-equal": "^0.2.0"
       },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/wms/node_modules/@loaders.gl/loader-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.2.tgz",
+      "integrity": "sha512-kqwBbyRC7rrQVsnJyKeoaig9hxaa5oj91OKqWm27HPuVn4q2dD67SEhiG0ND62eRp0tLY6jTqEcI5kDzHBZ6MA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
+      }
+    },
+    "node_modules/@loaders.gl/wms/node_modules/@loaders.gl/schema": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.2.tgz",
+      "integrity": "sha512-mJTZehTHIFl8ed+03nebuPAMnLP8Yp00DKTzCnKT2HNy/uV4+Sw+GrGIuhPHGU8tdQmtBXRURGM2ZxUAxMfGKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/wms/node_modules/@loaders.gl/worker-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.2.tgz",
+      "integrity": "sha512-oiZ0SoC1QKrOkhYPlVZ6Q06CtmuFRyZw2rwzmT08ZyaGtOArIJHDjlhxzwWiv+6fdws47Ub5uIGsdI1Ab1xYsA==",
+      "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@loaders.gl/core": "~4.4.0"
       }
@@ -971,33 +1343,101 @@
       }
     },
     "node_modules/@loaders.gl/xml": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/xml/-/xml-4.4.1.tgz",
-      "integrity": "sha512-+8Dtxp0BZZj1CVUkiIlKGDLmhwsPILK9yJvc1P7tuJO9KsaQ5cywJk/b8A7lmqb2SfPkEg0xlQOK2FWIo1ATMA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/xml/-/xml-4.4.2.tgz",
+      "integrity": "sha512-OOPqpYH1PK9szuzXh3Oy7aErMXTXB+aiKi79LPCI93Wsb8pdbQiDiRRW8X/op9qABhxpCAMXF5N89eDJv3XdtQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.4.1",
-        "@loaders.gl/schema": "4.4.1",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
         "fast-xml-parser": "^5.3.6"
       },
       "peerDependencies": {
         "@loaders.gl/core": "~4.4.0"
       }
     },
-    "node_modules/@loaders.gl/zip": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/zip/-/zip-4.4.1.tgz",
-      "integrity": "sha512-fV7oqREEzzqYl2/b4tiM+J4qeSq6pB4gw1hHngpCtVyjVwWVtsNH2r1ly9kkv4XssIdXJxPcrX/GR0mDIwmp6w==",
+    "node_modules/@loaders.gl/xml/node_modules/@loaders.gl/loader-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.2.tgz",
+      "integrity": "sha512-kqwBbyRC7rrQVsnJyKeoaig9hxaa5oj91OKqWm27HPuVn4q2dD67SEhiG0ND62eRp0tLY6jTqEcI5kDzHBZ6MA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@loaders.gl/compression": "4.4.1",
-        "@loaders.gl/crypto": "4.4.1",
-        "@loaders.gl/loader-utils": "4.4.1",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
+      }
+    },
+    "node_modules/@loaders.gl/xml/node_modules/@loaders.gl/schema": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.2.tgz",
+      "integrity": "sha512-mJTZehTHIFl8ed+03nebuPAMnLP8Yp00DKTzCnKT2HNy/uV4+Sw+GrGIuhPHGU8tdQmtBXRURGM2ZxUAxMfGKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/xml/node_modules/@loaders.gl/worker-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.2.tgz",
+      "integrity": "sha512-oiZ0SoC1QKrOkhYPlVZ6Q06CtmuFRyZw2rwzmT08ZyaGtOArIJHDjlhxzwWiv+6fdws47Ub5uIGsdI1Ab1xYsA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/zip": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/zip/-/zip-4.4.2.tgz",
+      "integrity": "sha512-KdgmJRNra9+9jt2zzHUvFXnBqwzeN7dW4MEgTmH/NtraGy8bz5Tk5NrIUj8JXPxhx+vP2vxUWbeCEUoLGO/m9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/compression": "4.4.2",
+        "@loaders.gl/crypto": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
         "jszip": "^3.1.5",
         "md5": "^2.3.0"
       },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/zip/node_modules/@loaders.gl/loader-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.2.tgz",
+      "integrity": "sha512-kqwBbyRC7rrQVsnJyKeoaig9hxaa5oj91OKqWm27HPuVn4q2dD67SEhiG0ND62eRp0tLY6jTqEcI5kDzHBZ6MA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
+      }
+    },
+    "node_modules/@loaders.gl/zip/node_modules/@loaders.gl/schema": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.2.tgz",
+      "integrity": "sha512-mJTZehTHIFl8ed+03nebuPAMnLP8Yp00DKTzCnKT2HNy/uV4+Sw+GrGIuhPHGU8tdQmtBXRURGM2ZxUAxMfGKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/zip/node_modules/@loaders.gl/worker-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.2.tgz",
+      "integrity": "sha512-oiZ0SoC1QKrOkhYPlVZ6Q06CtmuFRyZw2rwzmT08ZyaGtOArIJHDjlhxzwWiv+6fdws47Ub5uIGsdI1Ab1xYsA==",
+      "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@loaders.gl/core": "~4.4.0"
       }
@@ -1254,33 +1694,13 @@
       }
     },
     "node_modules/@math.gl/polygon": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-3.6.3.tgz",
-      "integrity": "sha512-FivQ1ZnYcAss1wVifOkHP/ZnlfQy1IL/769uzNtiHxwUbW0kZG3yyOZ9I7fwyzR5Hvqt3ErJKHjSYZr0uVlz5g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-4.1.0.tgz",
+      "integrity": "sha512-YA/9PzaCRHbIP5/0E9uTYrqe+jsYTQoqoDWhf6/b0Ixz8bPZBaGDEafLg3z7ffBomZLacUty9U3TlPjqMtzPjA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@math.gl/core": "3.6.3"
+        "@math.gl/core": "4.1.0"
       }
-    },
-    "node_modules/@math.gl/polygon/node_modules/@math.gl/core": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.6.3.tgz",
-      "integrity": "sha512-jBABmDkj5uuuE0dTDmwwss7Cup5ZwQ6Qb7h1pgvtkEutTrhkcv8SuItQNXmF45494yIHeoGue08NlyeY6wxq2A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.0",
-        "@math.gl/types": "3.6.3",
-        "gl-matrix": "^3.4.0"
-      }
-    },
-    "node_modules/@math.gl/polygon/node_modules/@math.gl/types": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@math.gl/types/-/types-3.6.3.tgz",
-      "integrity": "sha512-3uWLVXHY3jQxsXCr/UCNPSc2BG0hNUljhmOBt9l+lNFDp7zHgm0cK2Tw4kj2XfkJy4TgwZTBGwRDQgWEbLbdTA==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@math.gl/sun": {
       "version": "4.1.0",
@@ -1328,9 +1748,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
       "funding": [
         {
           "type": "github",
@@ -2082,14 +2502,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/offscreencanvas": {
@@ -3150,9 +3570,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -3162,13 +3582,14 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
-      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "funding": [
         {
           "type": "github",
@@ -3179,9 +3600,10 @@
       "peer": true,
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
+        "fast-xml-builder": "^1.2.0",
         "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -4708,9 +5130,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -4864,9 +5286,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT",
       "optional": true,
       "peer": true
@@ -5134,6 +5556,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@deck.gl/layers": "^9.3.0",
     "@deck.gl/mapbox": "^9.3.0",
     "@duckdb/duckdb-wasm": "^1.33.1-dev45.0",
-    "@geoarrow/deck.gl-layers": "^0.3.2",
+    "@geoarrow/deck.gl-geoarrow": "^0.4.1",
     "@mdi/font": "^7.4.47",
     "@theace0296/vue-snotify": "^4.0.4",
     "@vueuse/core": "^14.2.1",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "load-extensions": "node load-extensions.js"
   },
   "dependencies": {
-    "@deck.gl/core": "^9.3.0",
-    "@deck.gl/layers": "^9.3.0",
-    "@deck.gl/mapbox": "^9.3.0",
+    "@deck.gl/core": "^9.3.2",
+    "@deck.gl/layers": "^9.3.2",
+    "@deck.gl/mapbox": "^9.3.2",
     "@duckdb/duckdb-wasm": "^1.33.1-dev45.0",
     "@geoarrow/deck.gl-geoarrow": "^0.4.1",
     "@mdi/font": "^7.4.47",

--- a/src/components/MapView.vue
+++ b/src/components/MapView.vue
@@ -18,7 +18,7 @@ import {
   GeoArrowPathLayer,
   GeoArrowPolygonLayer,
   GeoArrowScatterplotLayer
-} from '@geoarrow/deck.gl-layers';
+} from '@geoarrow/deck.gl-geoarrow';
 import { parseWKB } from '@walkthru-earth/objex-utils';
 
 const NORMAL_FILL = [51, 153, 204, 120];


### PR DESCRIPTION
Update renamed package and deckgl packages to resolve the following warning:

```
⚠️ @geoarrow/deck.gl-layers has been renamed to @geoarrow/deck.gl-geoarrow. No further releases will be published under the name @geoarrow/deck.gl-layers. Please update your dependencies.
```